### PR TITLE
Cross

### DIFF
--- a/src/sc2protocol/CMakeLists.txt
+++ b/src/sc2protocol/CMakeLists.txt
@@ -44,6 +44,19 @@ if (WSL2_CROSS_COMPILE)
     endforeach ()
 # Compile protos with protoc
 else ()
+    if (NOT Protobuf_PROTOC_EXECUTABLE)
+        message(STATUS "Searching for Protoc compiler (protoc)")
+        find_program(Protobuf_PROTOC_EXECUTABLE
+                NAMES protoc
+                PATHS /usr/bin /usr/local/bin ${PROJECT_BINARY_DIR}/bin
+                NO_CMAKE_FIND_ROOT_PATH
+        )
+    endif()
+
+    if (NOT Protobuf_PROTOC_EXECUTABLE)
+        message(FATAL_ERROR "Protobuf compiler (protoc) not specified and not found on host!")
+    endif()
+
     foreach (proto ${proto_files})
         get_filename_component(proto_name_we ${proto} NAME_WE)
         set(protoc_out_cc "${proto_generation_dir}/${proto_name_we}.pb.cc")
@@ -54,11 +67,11 @@ else ()
                 "${protoc_out_cc}"
                 "${protoc_out_h}"
             COMMAND
-                "${PROJECT_BINARY_DIR}/bin/protoc"
+                "${Protobuf_PROTOC_EXECUTABLE}"
                 "-I=${sc2protocol_SOURCE_DIR}"
                 "--cpp_out=${PROJECT_BINARY_DIR}/generated"
                 "${proto}"
-            DEPENDS protoc
+            DEPENDS ${Protobuf_PROTOC_EXECUTABLE} ${proto_files}
             VERBATIM
         )
     endforeach()

--- a/src/sc2protocol/CMakeLists.txt
+++ b/src/sc2protocol/CMakeLists.txt
@@ -44,7 +44,7 @@ if (WSL2_CROSS_COMPILE)
     endforeach ()
 # Compile protos with protoc
 else ()
-    set(protoc_executable Protobuf_PROTOC_EXECUTABLE)
+    set(protoc_executable ${Protobuf_PROTOC_EXECUTABLE})
     if (NOT protoc_executable)
         set(protoc_executable ${PROJECT_BINARY_DIR}/bin/protoc)
     endif()

--- a/src/sc2protocol/CMakeLists.txt
+++ b/src/sc2protocol/CMakeLists.txt
@@ -44,17 +44,9 @@ if (WSL2_CROSS_COMPILE)
     endforeach ()
 # Compile protos with protoc
 else ()
-    if (NOT Protobuf_PROTOC_EXECUTABLE)
-        message(STATUS "Searching for Protoc compiler (protoc)")
-        find_program(Protobuf_PROTOC_EXECUTABLE
-                NAMES protoc
-                PATHS /usr/bin /usr/local/bin ${PROJECT_BINARY_DIR}/bin
-                NO_CMAKE_FIND_ROOT_PATH
-        )
-    endif()
-
-    if (NOT Protobuf_PROTOC_EXECUTABLE)
-        message(FATAL_ERROR "Protobuf compiler (protoc) not specified and not found on host!")
+    set(protoc_executable Protobuf_PROTOC_EXECUTABLE)
+    if (NOT protoc_executable)
+        set(protoc_executable ${PROJECT_BINARY_DIR}/bin/protoc)
     endif()
 
     foreach (proto ${proto_files})
@@ -67,11 +59,11 @@ else ()
                 "${protoc_out_cc}"
                 "${protoc_out_h}"
             COMMAND
-                "${Protobuf_PROTOC_EXECUTABLE}"
+                "${protoc_executable}"
                 "-I=${sc2protocol_SOURCE_DIR}"
                 "--cpp_out=${PROJECT_BINARY_DIR}/generated"
                 "${proto}"
-            DEPENDS ${Protobuf_PROTOC_EXECUTABLE} ${proto_files}
+            DEPENDS ${protoc_executable} ${proto_files}
             VERBATIM
         )
     endforeach()

--- a/thirdparty/cmake/protobuf.cmake
+++ b/thirdparty/cmake/protobuf.cmake
@@ -4,7 +4,7 @@ set(protobuf_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 set(protobuf_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
 
 # Do not build Protobuf compiler if using precompiled proto files
-if (WSL2_CROSS_COMPILE)
+if (WSL2_CROSS_COMPILE OR Protobuf_PROTOC_EXECUTABLE)
     set(protobuf_BUILD_PROTOC_BINARIES OFF CACHE BOOL "" FORCE)
 endif ()
 


### PR DESCRIPTION
The Protobuf_PROTOC_EXECUTABLE option will now be respected if provided and not build a Protoc executable and will use that provided one to build the proto files. The WSL2_CROSS_COMPILE option was left as it was so if enabled the project will use the precompiled protos instead of attempting to make its own

Note: Provided executable must be the same version as the version of Protobuf being compiled against. So currently that is v33.0